### PR TITLE
Sort `keys`

### DIFF
--- a/src/include/variant_extension.hpp
+++ b/src/include/variant_extension.hpp
@@ -136,6 +136,8 @@ struct VariantVector {
 	static Vector &GetValue(Vector &vec) {
 		return *StructVector::GetEntries(vec)[3];
 	}
+
+	static void SortVariantKeys(Vector &dictionary, idx_t dictionary_size, SelectionVector &sel, idx_t sel_size);
 };
 
 class VariantExtension : public Extension {

--- a/src/to_variant.cpp
+++ b/src/to_variant.cpp
@@ -975,6 +975,8 @@ bool VariantFunctions::CastToVARIANT(Vector &source, Vector &result, idx_t count
 		ConvertToVariant<true>(source, result_data, offsets, count, nullptr, keys_selvec, dictionary, nullptr);
 	}
 
+	VariantVector::SortVariantKeys(keys_entry, dictionary.dictionary.size(), keys_selvec, keys_selvec_size);
+
 	keys_entry.Slice(keys_selvec, keys_selvec_size);
 
 	if (source.GetVectorType() == VectorType::CONSTANT_VECTOR) {

--- a/src/variant_extension.cpp
+++ b/src/variant_extension.cpp
@@ -12,6 +12,52 @@ namespace duckdb {
 
 static constexpr auto VARIANT_TYPE_NAME = "VARIANT";
 
+void VariantVector::SortVariantKeys(Vector &dictionary, idx_t dictionary_size, SelectionVector &sel, idx_t sel_size) {
+	auto &allocator = Allocator::DefaultAllocator();
+	auto dictionary_data = FlatVector::GetData<string_t>(dictionary);
+
+	//! string + unsorted_index
+	vector<std::pair<reference<string_t>, idx_t>> strings;
+	strings.reserve(dictionary_size);
+	for (idx_t i = 0; i < dictionary_size; i++) {
+		strings.emplace_back(dictionary_data[i], i);
+	}
+
+	//! Sort the unique strings
+	std::sort(strings.begin(), strings.end(), [](const std::pair<reference<string_t>, idx_t> &a, const std::pair<reference<string_t>, idx_t> &b) {
+		return a.first.get() < b.first.get();
+	});
+
+	bool is_already_sorted = true;
+	vector<idx_t> unsorted_to_sorted(strings.size());
+	for (idx_t i = 0; i < strings.size(); i++) {
+		if (i != strings[i].second) {
+			is_already_sorted = false;
+		}
+		unsorted_to_sorted[strings[i].second] = i;
+	}
+
+	if (is_already_sorted) {
+		return;
+	}
+
+	//! Adjust the selection vector to point to the right dictionary index
+	for (idx_t i = 0; i < sel_size; i++) {
+		auto old_dictionary_index = sel.get_index(i);
+		auto new_dictionary_index = unsorted_to_sorted[old_dictionary_index];
+		sel.set_index(i, new_dictionary_index);
+	}
+
+	//! Finally, rewrite the dictionary itself
+	auto copied_dictionary = allocator.Allocate(sizeof(string_t) * dictionary_size);
+	auto copied_dictionary_data = reinterpret_cast<string_t *>(copied_dictionary.get());
+	memcpy(copied_dictionary_data, dictionary_data, sizeof(string_t) * dictionary_size);
+
+	for (idx_t i = 0; i < dictionary_size; i++) {
+		dictionary_data[i] = copied_dictionary_data[strings[i].second];
+	}
+}
+
 static LogicalType CreateVariantType() {
 	child_list_t<LogicalType> top_level_children;
 	top_level_children.emplace_back("keys", LogicalType::LIST(LogicalType::VARCHAR));

--- a/src/variant_functions.cpp
+++ b/src/variant_functions.cpp
@@ -276,6 +276,55 @@ static optional_idx ConvertJSON(yyjson_val *val, Vector &result, VariantConversi
 	return index;
 }
 
+static void SortVariantKeys(Vector &result, VariantConversionState &state) {
+	auto &allocator = Allocator::DefaultAllocator();
+
+	auto &dictionary = ListVector::GetEntry(VariantVector::GetKeys(result));
+	idx_t dictionary_size = state.dictionary.size();
+	auto dictionary_data = FlatVector::GetData<string_t>(dictionary);
+
+	//! string + unsorted_index
+	vector<std::pair<reference<string_t>, idx_t>> strings;
+	strings.reserve(dictionary_size);
+	for (idx_t i = 0; i < dictionary_size; i++) {
+		strings.emplace_back(dictionary_data[i], i);
+	}
+
+	//! Sort the unique strings
+	std::sort(strings.begin(), strings.end(), [](const std::pair<reference<string_t>, idx_t> &a, const std::pair<reference<string_t>, idx_t> &b) {
+		return a.first.get() < b.first.get();
+	});
+
+	bool is_already_sorted = true;
+	vector<idx_t> unsorted_to_sorted(strings.size());
+	for (idx_t i = 0; i < strings.size(); i++) {
+		if (i != strings[i].second) {
+			is_already_sorted = false;
+		}
+		unsorted_to_sorted[strings[i].second] = i;
+	}
+
+	if (is_already_sorted) {
+		return;
+	}
+
+	//! Adjust the selection vector to point to the right dictionary index
+	for (idx_t i = 0; i < state.keys_count; i++) {
+		auto old_dictionary_index = state.sel_vec.get_index(i);
+		auto new_dictionary_index = unsorted_to_sorted[old_dictionary_index];
+		state.sel_vec.set_index(i, new_dictionary_index);
+	}
+
+	//! Finally, rewrite the dictionary itself
+	auto copied_dictionary = allocator.Allocate(sizeof(string_t) * dictionary_size);
+	auto copied_dictionary_data = reinterpret_cast<string_t *>(copied_dictionary.get());
+	memcpy(copied_dictionary_data, dictionary_data, sizeof(string_t) * dictionary_size);
+
+	for (idx_t i = 0; i < dictionary_size; i++) {
+		dictionary_data[i] = copied_dictionary_data[strings[i].second];
+	}
+}
+
 bool VariantFunctions::CastJSONToVARIANT(Vector &source, Vector &result, idx_t count, CastParameters &parameters) {
 	UnifiedVectorFormat source_format;
 	source.ToUnifiedFormat(count, source_format);
@@ -344,6 +393,7 @@ bool VariantFunctions::CastJSONToVARIANT(Vector &source, Vector &result, idx_t c
 		state.Reset();
 	}
 
+	SortVariantKeys(result, state);
 	auto &keys_entry = ListVector::GetEntry(keys);
 	keys_entry.Slice(state.sel_vec, state.keys_count);
 

--- a/src/variant_functions.cpp
+++ b/src/variant_functions.cpp
@@ -276,55 +276,6 @@ static optional_idx ConvertJSON(yyjson_val *val, Vector &result, VariantConversi
 	return index;
 }
 
-static void SortVariantKeys(Vector &result, VariantConversionState &state) {
-	auto &allocator = Allocator::DefaultAllocator();
-
-	auto &dictionary = ListVector::GetEntry(VariantVector::GetKeys(result));
-	idx_t dictionary_size = state.dictionary.size();
-	auto dictionary_data = FlatVector::GetData<string_t>(dictionary);
-
-	//! string + unsorted_index
-	vector<std::pair<reference<string_t>, idx_t>> strings;
-	strings.reserve(dictionary_size);
-	for (idx_t i = 0; i < dictionary_size; i++) {
-		strings.emplace_back(dictionary_data[i], i);
-	}
-
-	//! Sort the unique strings
-	std::sort(strings.begin(), strings.end(), [](const std::pair<reference<string_t>, idx_t> &a, const std::pair<reference<string_t>, idx_t> &b) {
-		return a.first.get() < b.first.get();
-	});
-
-	bool is_already_sorted = true;
-	vector<idx_t> unsorted_to_sorted(strings.size());
-	for (idx_t i = 0; i < strings.size(); i++) {
-		if (i != strings[i].second) {
-			is_already_sorted = false;
-		}
-		unsorted_to_sorted[strings[i].second] = i;
-	}
-
-	if (is_already_sorted) {
-		return;
-	}
-
-	//! Adjust the selection vector to point to the right dictionary index
-	for (idx_t i = 0; i < state.keys_count; i++) {
-		auto old_dictionary_index = state.sel_vec.get_index(i);
-		auto new_dictionary_index = unsorted_to_sorted[old_dictionary_index];
-		state.sel_vec.set_index(i, new_dictionary_index);
-	}
-
-	//! Finally, rewrite the dictionary itself
-	auto copied_dictionary = allocator.Allocate(sizeof(string_t) * dictionary_size);
-	auto copied_dictionary_data = reinterpret_cast<string_t *>(copied_dictionary.get());
-	memcpy(copied_dictionary_data, dictionary_data, sizeof(string_t) * dictionary_size);
-
-	for (idx_t i = 0; i < dictionary_size; i++) {
-		dictionary_data[i] = copied_dictionary_data[strings[i].second];
-	}
-}
-
 bool VariantFunctions::CastJSONToVARIANT(Vector &source, Vector &result, idx_t count, CastParameters &parameters) {
 	UnifiedVectorFormat source_format;
 	source.ToUnifiedFormat(count, source_format);
@@ -393,9 +344,14 @@ bool VariantFunctions::CastJSONToVARIANT(Vector &source, Vector &result, idx_t c
 		state.Reset();
 	}
 
-	SortVariantKeys(result, state);
-	auto &keys_entry = ListVector::GetEntry(keys);
-	keys_entry.Slice(state.sel_vec, state.keys_count);
+	auto &dictionary = ListVector::GetEntry(keys);
+	auto dictionary_size = state.dictionary.size();
+
+	auto &sel = state.sel_vec;
+	auto sel_size = state.keys_count;
+
+	VariantVector::SortVariantKeys(dictionary, dictionary_size, sel, sel_size);
+	dictionary.Slice(state.sel_vec, state.keys_count);
 
 	if (source.GetVectorType() == VectorType::CONSTANT_VECTOR) {
 		result.SetVectorType(VectorType::CONSTANT_VECTOR);


### PR DESCRIPTION
This PR fixes #2 

It was simpler than described there
We only need to create a mapping between sorted<->unsorted indices, then rewrite the selection vector, and finally rewrite the `string_t` data of the dictionary.

We don't need to touch the `children.key_id` of the result at all