### PR TITLE
Variant Extract

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ set(LOADABLE_EXTENSION_NAME ${TARGET_NAME}_loadable_extension)
 project(${TARGET_NAME})
 include_directories(src/include)
 
-set(EXTENSION_SOURCES src/variant_extension.cpp src/variant_functions.cpp src/to_variant.cpp src/variant_to_varchar.cpp src/from_variant.cpp)
+set(EXTENSION_SOURCES src/variant_extension.cpp src/variant_functions.cpp src/to_variant.cpp src/variant_to_varchar.cpp src/from_variant.cpp src/variant_extract.cpp)
 
 build_static_extension(${TARGET_NAME} ${EXTENSION_SOURCES})
 build_loadable_extension(${TARGET_NAME} " " ${EXTENSION_SOURCES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ set(LOADABLE_EXTENSION_NAME ${TARGET_NAME}_loadable_extension)
 project(${TARGET_NAME})
 include_directories(src/include)
 
-set(EXTENSION_SOURCES src/variant_extension.cpp src/variant_functions.cpp src/to_variant.cpp src/variant_to_varchar.cpp src/from_variant.cpp src/variant_extract.cpp)
+set(EXTENSION_SOURCES src/variant_extension.cpp src/variant_functions.cpp src/to_variant.cpp src/variant_to_varchar.cpp src/from_variant.cpp src/variant_extract.cpp src/variant_utils.cpp)
 
 build_static_extension(${TARGET_NAME} ${EXTENSION_SOURCES})
 build_loadable_extension(${TARGET_NAME} " " ${EXTENSION_SOURCES})

--- a/src/from_variant.cpp
+++ b/src/from_variant.cpp
@@ -394,8 +394,9 @@ static bool ConvertVariantToStruct(FromVariantConversionData &conversion_data, V
 		//! FIXME: there is nothing preventing an OBJECT from containing the same key twice I believe ?
 		PathComponent component;
 		component.payload.key = string_t(child_name.c_str(), child_name.size());
-		if (!VariantUtils::FindChildValues<VariantChildLookupMode::BY_KEY>(conversion_data.unified_format, component,
-		                                                                   row, new_value_indices, child_data, count)) {
+		component.lookup_mode = VariantChildLookupMode::BY_KEY;
+		if (!VariantUtils::FindChildValues(conversion_data.unified_format, component, row, new_value_indices,
+		                                   child_data, count)) {
 			conversion_data.error = StringUtil::Format("VARIANT(OBJECT) is missing key '%s'");
 			return false;
 		}

--- a/src/include/variant_extension.hpp
+++ b/src/include/variant_extension.hpp
@@ -39,6 +39,8 @@ enum class VariantLogicalType : uint8_t {
 	ARRAY = 30
 };
 
+string VariantLogicalTypeToString(VariantLogicalType type);
+
 LogicalType CreateVariantType();
 
 template <class T>

--- a/src/include/variant_functions.hpp
+++ b/src/include/variant_functions.hpp
@@ -49,15 +49,10 @@ struct VariantNestedData {
 	uint32_t children_idx;
 };
 
-struct PathComponent;
-
-using variant_child_lookup_func_t =
-    std::function<void(RecursiveUnifiedVectorFormat &source, const PathComponent &component, optional_idx row,
-                       uint32_t *res, VariantNestedData *nested_data, idx_t count)>;
+enum class VariantChildLookupMode : uint8_t { BY_KEY, BY_INDEX };
 
 struct PathComponent {
-	//! Method used to find the requested child
-	variant_child_lookup_func_t func;
+	VariantChildLookupMode lookup_mode;
 	union {
 		string_t key;
 		uint32_t index;

--- a/src/include/variant_functions.hpp
+++ b/src/include/variant_functions.hpp
@@ -23,6 +23,16 @@ public:
 	static bool CastVARIANTToVARCHAR(Vector &source, Vector &result, idx_t count, CastParameters &parameters);
 };
 
+enum class VariantChildLookupMode : uint8_t { BY_KEY, BY_INDEX };
+
+struct PathComponent {
+	VariantChildLookupMode lookup_mode;
+	union {
+		string_t key;
+		uint32_t index;
+	} payload;
+};
+
 //! Extract a Variant from a Variant
 struct VariantExtract {
 	struct BindData : public FunctionData {
@@ -35,6 +45,7 @@ struct VariantExtract {
 
 	public:
 		string constant_path;
+		vector<PathComponent> components;
 	};
 
 	static void Func(DataChunk &input, ExpressionState &state, Vector &output);
@@ -47,16 +58,6 @@ struct VariantNestedData {
 	uint32_t child_count;
 	//! Index of the first child
 	uint32_t children_idx;
-};
-
-enum class VariantChildLookupMode : uint8_t { BY_KEY, BY_INDEX };
-
-struct PathComponent {
-	VariantChildLookupMode lookup_mode;
-	union {
-		string_t key;
-		uint32_t index;
-	} payload;
 };
 
 } // namespace duckdb

--- a/src/include/variant_utils.hpp
+++ b/src/include/variant_utils.hpp
@@ -5,70 +5,9 @@
 
 namespace duckdb {
 
-enum class VariantChildLookupMode : uint8_t { BY_KEY, BY_INDEX };
-
 struct VariantUtils {
-	template <VariantChildLookupMode MODE>
 	static bool FindChildValues(RecursiveUnifiedVectorFormat &source, const PathComponent &component, optional_idx row,
-	                            uint32_t *res, VariantNestedData *nested_data, idx_t count) {
-		//! children
-		auto &children = UnifiedVariantVector::GetChildren(source);
-		auto children_data = children.GetData<list_entry_t>(children);
-
-		//! value_ids
-		auto &value_ids = UnifiedVariantVector::GetChildrenValueId(source);
-		auto value_ids_data = value_ids.GetData<uint32_t>(value_ids);
-
-		//! key_ids
-		auto &key_ids = UnifiedVariantVector::GetChildrenKeyId(source);
-		auto key_ids_data = key_ids.GetData<uint32_t>(key_ids);
-
-		//! keys
-		auto &keys = UnifiedVariantVector::GetKeys(source);
-		auto keys_data = keys.GetData<list_entry_t>(keys);
-
-		//! entry of the keys list
-		auto &keys_entry = UnifiedVariantVector::GetKeysEntry(source);
-		auto keys_entry_data = keys_entry.GetData<string_t>(keys_entry);
-
-		for (idx_t i = 0; i < count; i++) {
-			auto row_index = row.IsValid() ? row.GetIndex() : i;
-			auto &children_list_entry = children_data[children.sel->get_index(row_index)];
-
-			auto &nested_data_entry = nested_data[i];
-			if (MODE == VariantChildLookupMode::BY_INDEX) {
-				auto child_idx = component.payload.index;
-				if (child_idx >= nested_data_entry.child_count) {
-					//! The list is too small to contain this index
-					return false;
-				}
-				auto children_index = children_list_entry.offset + nested_data_entry.children_idx + child_idx;
-				auto value_id = value_ids_data[value_ids.sel->get_index(children_index)];
-				res[i] = value_id;
-				continue;
-			}
-			auto &keys_list_entry = keys_data[keys.sel->get_index(row_index)];
-			bool found_child = false;
-			for (idx_t child_idx = 0; child_idx < nested_data_entry.child_count; child_idx++) {
-				auto children_index = children_list_entry.offset + nested_data_entry.children_idx + child_idx;
-				auto value_id = value_ids_data[value_ids.sel->get_index(children_index)];
-
-				auto key_id = key_ids_data[key_ids.sel->get_index(children_index)];
-				auto key_index = keys_entry.sel->get_index(keys_list_entry.offset + key_id);
-				auto &child_key = keys_entry_data[key_index];
-				if (child_key == component.payload.key) {
-					//! Found the key we're looking for
-					res[i] = value_id;
-					found_child = true;
-					break;
-				}
-			}
-			if (!found_child) {
-				return false;
-			}
-		}
-		return true;
-	}
+	                            uint32_t *res, VariantNestedData *nested_data, idx_t count);
 };
 
 } // namespace duckdb

--- a/src/include/variant_utils.hpp
+++ b/src/include/variant_utils.hpp
@@ -1,0 +1,74 @@
+#pragma once
+
+#include "variant_functions.hpp"
+#include "duckdb/common/types/vector.hpp"
+
+namespace duckdb {
+
+enum class VariantChildLookupMode : uint8_t { BY_KEY, BY_INDEX };
+
+struct VariantUtils {
+	template <VariantChildLookupMode MODE>
+	static bool FindChildValues(RecursiveUnifiedVectorFormat &source, const PathComponent &component, optional_idx row,
+	                            uint32_t *res, VariantNestedData *nested_data, idx_t count) {
+		//! children
+		auto &children = UnifiedVariantVector::GetChildren(source);
+		auto children_data = children.GetData<list_entry_t>(children);
+
+		//! value_ids
+		auto &value_ids = UnifiedVariantVector::GetChildrenValueId(source);
+		auto value_ids_data = value_ids.GetData<uint32_t>(value_ids);
+
+		//! key_ids
+		auto &key_ids = UnifiedVariantVector::GetChildrenKeyId(source);
+		auto key_ids_data = key_ids.GetData<uint32_t>(key_ids);
+
+		//! keys
+		auto &keys = UnifiedVariantVector::GetKeys(source);
+		auto keys_data = keys.GetData<list_entry_t>(keys);
+
+		//! entry of the keys list
+		auto &keys_entry = UnifiedVariantVector::GetKeysEntry(source);
+		auto keys_entry_data = keys_entry.GetData<string_t>(keys_entry);
+
+		for (idx_t i = 0; i < count; i++) {
+			auto row_index = row.IsValid() ? row.GetIndex() : i;
+			auto &children_list_entry = children_data[children.sel->get_index(row_index)];
+
+			auto &nested_data_entry = nested_data[i];
+			if (MODE == VariantChildLookupMode::BY_INDEX) {
+				auto child_idx = component.payload.index;
+				if (child_idx >= nested_data_entry.child_count) {
+					//! The list is too small to contain this index
+					return false;
+				}
+				auto children_index = children_list_entry.offset + nested_data_entry.children_idx + child_idx;
+				auto value_id = value_ids_data[value_ids.sel->get_index(children_index)];
+				res[i] = value_id;
+				continue;
+			}
+			auto &keys_list_entry = keys_data[keys.sel->get_index(row_index)];
+			bool found_child = false;
+			for (idx_t child_idx = 0; child_idx < nested_data_entry.child_count; child_idx++) {
+				auto children_index = children_list_entry.offset + nested_data_entry.children_idx + child_idx;
+				auto value_id = value_ids_data[value_ids.sel->get_index(children_index)];
+
+				auto key_id = key_ids_data[key_ids.sel->get_index(children_index)];
+				auto key_index = keys_entry.sel->get_index(keys_list_entry.offset + key_id);
+				auto &child_key = keys_entry_data[key_index];
+				if (child_key == component.payload.key) {
+					//! Found the key we're looking for
+					res[i] = value_id;
+					found_child = true;
+					break;
+				}
+			}
+			if (!found_child) {
+				return false;
+			}
+		}
+		return true;
+	}
+};
+
+} // namespace duckdb

--- a/src/include/variant_utils.hpp
+++ b/src/include/variant_utils.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "variant_functions.hpp"
+#include "variant_extension.hpp"
 #include "duckdb/common/types/vector.hpp"
 
 namespace duckdb {
@@ -8,6 +9,9 @@ namespace duckdb {
 struct VariantUtils {
 	static bool FindChildValues(RecursiveUnifiedVectorFormat &source, const PathComponent &component, optional_idx row,
 	                            uint32_t *res, VariantNestedData *nested_data, idx_t count);
+	static bool CollectNestedData(RecursiveUnifiedVectorFormat &variant, VariantLogicalType expected_type,
+	                              uint32_t *value_indices, idx_t count, optional_idx row, VariantNestedData *child_data,
+	                              string &error);
 };
 
 } // namespace duckdb

--- a/src/variant_extension.cpp
+++ b/src/variant_extension.cpp
@@ -84,6 +84,9 @@ static void LoadInternal(ExtensionLoader &loader) {
 	auto variant_type = CreateVariantType();
 	loader.RegisterType(VARIANT_TYPE_NAME, variant_type);
 
+	loader.RegisterFunction(ScalarFunction("variant_extract", {variant_type, LogicalType::VARCHAR}, variant_type,
+	                                       VariantExtract::Func, VariantExtract::Bind));
+
 	// add the casts to and from VARIANT type
 	loader.RegisterCastFunction(LogicalType::JSON(), variant_type, VariantFunctions::CastJSONToVARIANT, 5);
 	loader.RegisterCastFunction(variant_type, LogicalType::JSON(), VariantFunctions::CastVARIANTToJSON, 5);

--- a/src/variant_extract.cpp
+++ b/src/variant_extract.cpp
@@ -181,7 +181,7 @@ void VariantExtract::Func(DataChunk &input, ExpressionState &state, Vector &resu
 	SelectionVector new_sel(0, values_list_size);
 	for (idx_t i = 0; i < count; i++) {
 		auto &list_entry = values_data[values.sel->get_index(i)];
-		new_sel.set_index(list_entry.offset, result_indices[i]);
+		new_sel.set_index(list_entry.offset, list_entry.offset + result_indices[i]);
 	}
 
 	auto &raw_type_id = VariantVector::GetValuesTypeId(variant);

--- a/src/variant_extract.cpp
+++ b/src/variant_extract.cpp
@@ -1,0 +1,135 @@
+#include "variant_extension.hpp"
+#include "variant_functions.hpp"
+#include "variant_utils.hpp"
+#include "duckdb/function/scalar/regexp.hpp"
+
+namespace duckdb {
+
+namespace {
+
+using child_lookup_func_t =
+    std::function<void(RecursiveUnifiedVectorFormat &source, const PathComponent &component, optional_idx row,
+                       uint32_t *res, VariantNestedData *nested_data, idx_t count)>;
+
+enum class PathParsingState : uint8_t { BASE, KEY, INDEX };
+
+} // namespace
+
+using regexp_util::TryParseConstantPattern;
+
+vector<PathComponent> ParsePath(const string &path) {
+	vector<PathComponent> components;
+	auto state = PathParsingState::BASE;
+
+	idx_t i = 0;
+	while (i < path.size()) {
+		switch (state) {
+		case PathParsingState::BASE: {
+			if (path[i] == '.') {
+				// Skip dot, move to key state
+				i++;
+				state = PathParsingState::KEY;
+			} else if (path[i] == '[') {
+				// Start of an index
+				i++;
+				state = PathParsingState::INDEX;
+			} else {
+				// Start of key at base
+				state = PathParsingState::KEY;
+			}
+			break;
+		}
+		case PathParsingState::KEY: {
+			// Parse key until next '.' or '['
+			idx_t start = i;
+			while (i < path.size() && path[i] != '.' && path[i] != '[') {
+				i++;
+			}
+			auto key = string_t(path.c_str() + start, i - start);
+			PathComponent comp;
+			comp.func = VariantUtils::FindChildValues<VariantChildLookupMode::BY_KEY>;
+			comp.payload.key = std::move(key);
+			components.push_back(std::move(comp));
+			state = PathParsingState::BASE;
+			break;
+		}
+		case PathParsingState::INDEX: {
+			// Parse digits inside [ ]
+			idx_t start = i;
+			while (i < path.size() && isdigit(path[i])) {
+				i++;
+			}
+			if (i == start || i >= path.size() || path[i] != ']') {
+				throw BinderException("Invalid index in path: %s", path);
+			}
+			uint32_t index = std::stoul(path.substr(start, i - start));
+			i++; // skip ']'
+			PathComponent comp;
+			comp.func = VariantUtils::FindChildValues<VariantChildLookupMode::BY_INDEX>;
+			comp.payload.index = index;
+			components.push_back(std::move(comp));
+			state = PathParsingState::BASE;
+			break;
+		}
+		}
+	}
+	return components;
+}
+
+VariantExtract::BindData::BindData(const string &constant_path) : FunctionData(), constant_path(constant_path) {
+}
+
+unique_ptr<FunctionData> VariantExtract::BindData::Copy() const {
+	return make_uniq<BindData>(constant_path);
+}
+bool VariantExtract::BindData::Equals(const FunctionData &other) const {
+	auto &bind_data = other.Cast<BindData>();
+	return bind_data.constant_path == constant_path;
+}
+
+unique_ptr<FunctionData> VariantExtract::Bind(ClientContext &context, ScalarFunction &bound_function,
+                                              vector<unique_ptr<Expression>> &arguments) {
+	if (arguments.size() != 2) {
+		throw BinderException("'variant_extract' expects two arguments, VARIANT column and VARCHAR path");
+	}
+	auto &path = *arguments[1];
+	if (path.return_type.id() != LogicalTypeId::VARCHAR) {
+		throw BinderException("'variant_extract' expects the second argument to be of type VARCHAR, not %s",
+		                      path.return_type.ToString());
+	}
+	string constant_path;
+	if (!TryParseConstantPattern(context, path, constant_path)) {
+		throw BinderException("'variant_extract' expects the second argument (path) to be a constant expression");
+	}
+	return make_uniq<VariantExtract::BindData>(constant_path);
+}
+
+//! FIXME: it could make sense to allow a third argument: 'default'
+//! This can currently be achieved with COALESCE(TRY(<extract method>), 'default')
+void VariantExtract::Func(DataChunk &input, ExpressionState &state, Vector &result) {
+	auto count = input.size();
+
+	D_ASSERT(input.ColumnCount() == 2);
+	auto &variant = input.data[0];
+	D_ASSERT(variant.GetType() == CreateVariantType());
+
+	auto &path = input.data[1];
+	D_ASSERT(path.GetType().id() == LogicalTypeId::VARCHAR);
+	//! FIXME: do we want to assert that this is a constant, or allow different paths per row?
+	D_ASSERT(path.GetVectorType() == VectorType::CONSTANT_VECTOR);
+
+	RecursiveUnifiedVectorFormat source_format;
+	Vector::RecursiveToUnifiedFormat(variant, count, source_format);
+
+	//! Path either contains array indices or object keys
+	auto &validity = FlatVector::Validity(result);
+	for (idx_t i = 0; i < count; i++) {
+		validity.SetInvalid(i);
+	}
+
+	if (input.AllConstant()) {
+		result.SetVectorType(VectorType::CONSTANT_VECTOR);
+	}
+}
+
+} // namespace duckdb

--- a/src/variant_extract.cpp
+++ b/src/variant_extract.cpp
@@ -47,7 +47,7 @@ vector<PathComponent> ParsePath(const string &path) {
 			}
 			auto key = string_t(path.c_str() + start, i - start);
 			PathComponent comp;
-			comp.func = VariantUtils::FindChildValues<VariantChildLookupMode::BY_KEY>;
+			comp.lookup_mode = VariantChildLookupMode::BY_KEY;
 			comp.payload.key = std::move(key);
 			components.push_back(std::move(comp));
 			state = PathParsingState::BASE;
@@ -65,7 +65,7 @@ vector<PathComponent> ParsePath(const string &path) {
 			uint32_t index = std::stoul(path.substr(start, i - start));
 			i++; // skip ']'
 			PathComponent comp;
-			comp.func = VariantUtils::FindChildValues<VariantChildLookupMode::BY_INDEX>;
+			comp.lookup_mode = VariantChildLookupMode::BY_INDEX;
 			comp.payload.index = index;
 			components.push_back(std::move(comp));
 			state = PathParsingState::BASE;

--- a/src/variant_utils.cpp
+++ b/src/variant_utils.cpp
@@ -1,0 +1,67 @@
+#include "variant_utils.hpp"
+#include "variant_extension.hpp"
+
+namespace duckdb {
+
+bool VariantUtils::FindChildValues(RecursiveUnifiedVectorFormat &source, const PathComponent &component,
+                                   optional_idx row, uint32_t *res, VariantNestedData *nested_data, idx_t count) {
+	//! children
+	auto &children = UnifiedVariantVector::GetChildren(source);
+	auto children_data = children.GetData<list_entry_t>(children);
+
+	//! value_ids
+	auto &value_ids = UnifiedVariantVector::GetChildrenValueId(source);
+	auto value_ids_data = value_ids.GetData<uint32_t>(value_ids);
+
+	//! key_ids
+	auto &key_ids = UnifiedVariantVector::GetChildrenKeyId(source);
+	auto key_ids_data = key_ids.GetData<uint32_t>(key_ids);
+
+	//! keys
+	auto &keys = UnifiedVariantVector::GetKeys(source);
+	auto keys_data = keys.GetData<list_entry_t>(keys);
+
+	//! entry of the keys list
+	auto &keys_entry = UnifiedVariantVector::GetKeysEntry(source);
+	auto keys_entry_data = keys_entry.GetData<string_t>(keys_entry);
+
+	for (idx_t i = 0; i < count; i++) {
+		auto row_index = row.IsValid() ? row.GetIndex() : i;
+		auto &children_list_entry = children_data[children.sel->get_index(row_index)];
+
+		auto &nested_data_entry = nested_data[i];
+		if (component.lookup_mode == VariantChildLookupMode::BY_INDEX) {
+			auto child_idx = component.payload.index;
+			if (child_idx >= nested_data_entry.child_count) {
+				//! The list is too small to contain this index
+				return false;
+			}
+			auto children_index = children_list_entry.offset + nested_data_entry.children_idx + child_idx;
+			auto value_id = value_ids_data[value_ids.sel->get_index(children_index)];
+			res[i] = value_id;
+			continue;
+		}
+		auto &keys_list_entry = keys_data[keys.sel->get_index(row_index)];
+		bool found_child = false;
+		for (idx_t child_idx = 0; child_idx < nested_data_entry.child_count; child_idx++) {
+			auto children_index = children_list_entry.offset + nested_data_entry.children_idx + child_idx;
+			auto value_id = value_ids_data[value_ids.sel->get_index(children_index)];
+
+			auto key_id = key_ids_data[key_ids.sel->get_index(children_index)];
+			auto key_index = keys_entry.sel->get_index(keys_list_entry.offset + key_id);
+			auto &child_key = keys_entry_data[key_index];
+			if (child_key == component.payload.key) {
+				//! Found the key we're looking for
+				res[i] = value_id;
+				found_child = true;
+				break;
+			}
+		}
+		if (!found_child) {
+			return false;
+		}
+	}
+	return true;
+}
+
+} // namespace duckdb

--- a/test/sql/variant_extract.test
+++ b/test/sql/variant_extract.test
@@ -1,0 +1,43 @@
+# name: test/sql/variant_extract.test
+# group: [sql]
+
+require variant
+
+require json
+
+query I
+select variant_extract({'a': 1234}::VARIANT, 'a')::VARCHAR;
+----
+1234
+
+statement ok
+create table struct_cast_tbl3(a VARIANT);
+
+statement ok
+insert into struct_cast_tbl3 select {'a': [
+	{
+		'b': 'hello',
+		'c': NULL,
+		'a': '1970/03/15'::DATE
+	},
+	{
+		'b': NULL,
+		'c': True,
+		'a': '2020/11/03'::DATE
+	}
+]}::VARIANT;
+
+statement ok
+insert into struct_cast_tbl3 select {'a': [
+	{
+		'b': 'this is a long string',
+		'c': False,
+		'a': '1953/9/16'::DATE
+	}
+]}::VARIANT;
+
+query I
+select variant_extract(a, 'a[0].c') from struct_cast_tbl3;
+----
+NULL
+false


### PR DESCRIPTION
This PR implements the scalar function `VARIANT_EXTRACT(VARIANT, VARCHAR) -> VARIANT`

The function takes in a VARIANT column and a VARCHAR column, representing a path to extract from the variant.
Paths can consist of key names and array indices, separated by dots, i.e: `my_key[0].nested_key.deeper_nested_key[2]`

This path currently has to be a constant expression.
At bind time the path is transformed into path components, at runtime these are traversed in order, and finally these retrieved value indices are mapped to index 0 for their respective rows.

This makes it so that the function does not require any new memory to be allocated, the existing memory of the input VARIANT is used instead.