### PR TITLE
Add `variant_typeof`, fix bug in `variant_extract` causing the input to be altered

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ set(LOADABLE_EXTENSION_NAME ${TARGET_NAME}_loadable_extension)
 project(${TARGET_NAME})
 include_directories(src/include)
 
-set(EXTENSION_SOURCES src/variant_extension.cpp src/variant_functions.cpp src/to_variant.cpp src/variant_to_varchar.cpp src/from_variant.cpp src/variant_extract.cpp src/variant_utils.cpp)
+set(EXTENSION_SOURCES src/variant_extension.cpp src/variant_functions.cpp src/to_variant.cpp src/variant_to_varchar.cpp src/from_variant.cpp src/variant_extract.cpp src/variant_utils.cpp src/variant_typeof.cpp)
 
 build_static_extension(${TARGET_NAME} ${EXTENSION_SOURCES})
 build_loadable_extension(${TARGET_NAME} " " ${EXTENSION_SOURCES})

--- a/src/include/variant_functions.hpp
+++ b/src/include/variant_functions.hpp
@@ -45,6 +45,8 @@ struct VariantExtract {
 
 	public:
 		string constant_path;
+		//! NOTE: the keys in here reference data of the 'constant_path',
+		//! the components can not be copied without reconstruction
 		vector<PathComponent> components;
 	};
 
@@ -58,6 +60,11 @@ struct VariantNestedData {
 	uint32_t child_count;
 	//! Index of the first child
 	uint32_t children_idx;
+};
+
+struct VariantTypeof {
+public:
+	static void Func(DataChunk &input, ExpressionState &state, Vector &output);
 };
 
 } // namespace duckdb

--- a/src/variant_extension.cpp
+++ b/src/variant_extension.cpp
@@ -86,6 +86,8 @@ static void LoadInternal(ExtensionLoader &loader) {
 
 	loader.RegisterFunction(ScalarFunction("variant_extract", {variant_type, LogicalType::VARCHAR}, variant_type,
 	                                       VariantExtract::Func, VariantExtract::Bind));
+	loader.RegisterFunction(
+	    ScalarFunction("variant_typeof", {variant_type}, LogicalType::VARCHAR, VariantTypeof::Func, nullptr));
 
 	// add the casts to and from VARIANT type
 	loader.RegisterCastFunction(LogicalType::JSON(), variant_type, VariantFunctions::CastJSONToVARIANT, 5);

--- a/src/variant_extract.cpp
+++ b/src/variant_extract.cpp
@@ -178,14 +178,13 @@ void VariantExtract::Func(DataChunk &input, ExpressionState &state, Vector &resu
 	auto values_list_size = ListVector::GetListSize(raw_values);
 
 	//! Create a new Variant that references the existing data of the input Variant
-	Vector result_variant(variant.GetType(), false);
-	result_variant.Initialize(false, count);
-	VariantVector::GetKeys(result_variant).Reference(VariantVector::GetKeys(variant));
-	VariantVector::GetChildren(result_variant).Reference(VariantVector::GetChildren(variant));
-	VariantVector::GetValue(result_variant).Reference(VariantVector::GetValue(variant));
+	result.Initialize(false, count);
+	VariantVector::GetKeys(result).Reference(VariantVector::GetKeys(variant));
+	VariantVector::GetChildren(result).Reference(VariantVector::GetChildren(variant));
+	VariantVector::GetValue(result).Reference(VariantVector::GetValue(variant));
 
 	//! Copy the existing 'values'
-	auto &result_values = VariantVector::GetValues(result_variant);
+	auto &result_values = VariantVector::GetValues(result);
 	result_values.Initialize(false, count);
 	ListVector::Reserve(result_values, values_list_size);
 	ListVector::SetListSize(result_values, values_list_size);
@@ -193,7 +192,6 @@ void VariantExtract::Func(DataChunk &input, ExpressionState &state, Vector &resu
 	for (idx_t i = 0; i < count; i++) {
 		result_values_data[i] = values_data[values.sel->get_index(i)];
 	}
-	result.Reference(result_variant);
 
 	//! Prepare the selection vector to remap index 0 of each row
 	SelectionVector new_sel(0, values_list_size);

--- a/src/variant_extract.cpp
+++ b/src/variant_extract.cpp
@@ -178,8 +178,8 @@ void VariantExtract::Func(DataChunk &input, ExpressionState &state, Vector &resu
 	auto values_list_size = ListVector::GetListSize(raw_values);
 
 	//! Create a new Variant that references the existing data of the input Variant
-	Vector result_variant(variant.GetType(), false, false, count);
-	result_variant.SetAuxiliary(variant.GetAuxiliary());
+	Vector result_variant(variant.GetType(), false);
+	result_variant.Initialize(false, count);
 	VariantVector::GetKeys(result_variant).Reference(VariantVector::GetKeys(variant));
 	VariantVector::GetChildren(result_variant).Reference(VariantVector::GetChildren(variant));
 	VariantVector::GetValue(result_variant).Reference(VariantVector::GetValue(variant));
@@ -193,7 +193,6 @@ void VariantExtract::Func(DataChunk &input, ExpressionState &state, Vector &resu
 	for (idx_t i = 0; i < count; i++) {
 		result_values_data[i] = values_data[values.sel->get_index(i)];
 	}
-	ListVector::GetEntry(result_values).Reference(ListVector::GetEntry(VariantVector::GetValues(variant)));
 	result.Reference(result_variant);
 
 	//! Prepare the selection vector to remap index 0 of each row

--- a/src/variant_extract.cpp
+++ b/src/variant_extract.cpp
@@ -171,23 +171,43 @@ void VariantExtract::Func(DataChunk &input, ExpressionState &state, Vector &resu
 	//! We just need to remap index 0 of the 'values' list (for all rows)
 
 	auto result_indices = info.components.size() % 2 == 0 ? value_indices : new_value_indices;
-	result.Reference(variant);
-
-	auto &raw_values = VariantVector::GetValues(variant);
-	auto values_list_size = ListVector::GetListSize(raw_values);
 
 	auto &values = UnifiedVariantVector::GetValues(source_format);
 	auto values_data = values.GetData<list_entry_t>(values);
+	auto &raw_values = VariantVector::GetValues(variant);
+	auto values_list_size = ListVector::GetListSize(raw_values);
+
+	//! Create a new Variant that references the existing data of the input Variant
+	Vector result_variant(variant.GetType(), false, false, count);
+	result_variant.SetAuxiliary(variant.GetAuxiliary());
+	VariantVector::GetKeys(result_variant).Reference(VariantVector::GetKeys(variant));
+	VariantVector::GetChildren(result_variant).Reference(VariantVector::GetChildren(variant));
+	VariantVector::GetValue(result_variant).Reference(VariantVector::GetValue(variant));
+
+	//! Copy the existing 'values'
+	auto &result_values = VariantVector::GetValues(result_variant);
+	result_values.Initialize(false, count);
+	ListVector::Reserve(result_values, values_list_size);
+	ListVector::SetListSize(result_values, values_list_size);
+	auto result_values_data = FlatVector::GetData<list_entry_t>(result_values);
+	for (idx_t i = 0; i < count; i++) {
+		result_values_data[i] = values_data[values.sel->get_index(i)];
+	}
+	ListVector::GetEntry(result_values).Reference(ListVector::GetEntry(VariantVector::GetValues(variant)));
+	result.Reference(result_variant);
+
+	//! Prepare the selection vector to remap index 0 of each row
 	SelectionVector new_sel(0, values_list_size);
 	for (idx_t i = 0; i < count; i++) {
 		auto &list_entry = values_data[values.sel->get_index(i)];
 		new_sel.set_index(list_entry.offset, list_entry.offset + result_indices[i]);
 	}
 
-	auto &raw_type_id = VariantVector::GetValuesTypeId(variant);
-	auto &raw_byte_offset = VariantVector::GetValuesByteOffset(variant);
-	raw_type_id.Slice(new_sel, values_list_size);
-	raw_byte_offset.Slice(new_sel, values_list_size);
+	auto &result_type_id = VariantVector::GetValuesTypeId(result);
+	auto &result_byte_offset = VariantVector::GetValuesByteOffset(result);
+	result_type_id.Dictionary(VariantVector::GetValuesTypeId(variant), values_list_size, new_sel, values_list_size);
+	result_byte_offset.Dictionary(VariantVector::GetValuesByteOffset(variant), values_list_size, new_sel,
+	                              values_list_size);
 
 	if (input.AllConstant()) {
 		result.SetVectorType(VectorType::CONSTANT_VECTOR);

--- a/src/variant_typeof.cpp
+++ b/src/variant_typeof.cpp
@@ -1,0 +1,93 @@
+#include "variant_extension.hpp"
+#include "variant_functions.hpp"
+
+namespace duckdb {
+
+void VariantTypeof::Func(DataChunk &input, ExpressionState &state, Vector &result) {
+	auto count = input.size();
+
+	D_ASSERT(input.ColumnCount() == 1);
+	auto &variant = input.data[0];
+	D_ASSERT(variant.GetType() == CreateVariantType());
+
+	RecursiveUnifiedVectorFormat source_format;
+	Vector::RecursiveToUnifiedFormat(variant, count, source_format);
+
+	//! type_id
+	auto &type_id = UnifiedVariantVector::GetValuesTypeId(source_format);
+	auto type_id_data = type_id.GetData<uint8_t>(type_id);
+
+	//! byte_offset
+	auto &byte_offset = UnifiedVariantVector::GetValuesByteOffset(source_format);
+	auto byte_offset_data = byte_offset.GetData<uint32_t>(byte_offset);
+
+	//! values
+	auto &values = UnifiedVariantVector::GetValues(source_format);
+	auto values_data = values.GetData<list_entry_t>(values);
+
+	//! children
+	auto &children = UnifiedVariantVector::GetChildren(source_format);
+	auto children_data = children.GetData<list_entry_t>(children);
+
+	//! key_id
+	auto &key_id = UnifiedVariantVector::GetChildrenKeyId(source_format);
+	auto key_id_data = key_id.GetData<uint32_t>(key_id);
+
+	//! keys
+	auto &keys = UnifiedVariantVector::GetKeys(source_format);
+	auto keys_data = keys.GetData<list_entry_t>(keys);
+
+	//! keys entry
+	auto &keys_entry = UnifiedVariantVector::GetKeysEntry(source_format);
+	auto keys_entry_data = keys_entry.GetData<string_t>(keys_entry);
+
+	//! value
+	auto &value = UnifiedVariantVector::GetValue(source_format);
+	auto value_data = value.GetData<string_t>(value);
+
+	auto result_data = FlatVector::GetData<string_t>(result);
+	for (idx_t i = 0; i < count; i++) {
+		auto values_list_entry = values_data[values.sel->get_index(i)];
+		auto children_list_entry = children_data[children.sel->get_index(i)];
+		auto keys_list_entry = keys_data[keys.sel->get_index(i)];
+		auto type = static_cast<VariantLogicalType>(type_id_data[type_id.sel->get_index(values_list_entry.offset)]);
+
+		auto blob_data = value_data[value.sel->get_index(i)].GetData();
+
+		string type_str;
+		if (type == VariantLogicalType::OBJECT) {
+			auto value_byte_offset = byte_offset_data[byte_offset.sel->get_index(values_list_entry.offset)];
+			auto ptr = const_data_ptr_cast(blob_data + value_byte_offset);
+			auto child_count = VarintDecode<uint32_t>(ptr);
+			auto children_index = VarintDecode<uint32_t>(ptr);
+
+			vector<string> object_keys;
+			for (idx_t child_idx = 0; child_idx < child_count; child_idx++) {
+				auto child_key_id =
+				    key_id_data[key_id.sel->get_index(children_list_entry.offset + children_index + child_idx)];
+				object_keys.push_back(keys_entry_data[keys_list_entry.offset + child_key_id].GetString());
+			}
+			type_str = StringUtil::Format("OBJECT(%s)", StringUtil::Join(object_keys, ", "));
+		} else if (type == VariantLogicalType::ARRAY) {
+			auto value_byte_offset = byte_offset_data[byte_offset.sel->get_index(values_list_entry.offset)];
+			auto ptr = const_data_ptr_cast(blob_data + value_byte_offset);
+			auto child_count = VarintDecode<uint32_t>(ptr);
+			type_str = StringUtil::Format("ARRAY(%d)", child_count);
+		} else if (type == VariantLogicalType::DECIMAL) {
+			auto value_byte_offset = byte_offset_data[byte_offset.sel->get_index(values_list_entry.offset)];
+			auto ptr = const_data_ptr_cast(blob_data + value_byte_offset);
+			auto width = VarintDecode<uint32_t>(ptr);
+			auto scale = VarintDecode<uint32_t>(ptr);
+			type_str = StringUtil::Format("DECIMAL(%d, %d)", width, scale);
+		} else {
+			type_str = VariantLogicalTypeToString(type);
+		}
+		result_data[i] = StringVector::AddString(result, type_str.c_str());
+	}
+
+	if (input.AllConstant()) {
+		result.SetVectorType(VectorType::CONSTANT_VECTOR);
+	}
+}
+
+} // namespace duckdb

--- a/test/sql/variant_typeof.test
+++ b/test/sql/variant_typeof.test
@@ -64,7 +64,7 @@ ARRAY(0)
 ARRAY(3)
 VARIANT_NULL
 
-query I
+query III
 select variant_typeof(variant_extract(test, 'array_of_structs[0]')), variant_typeof(variant_extract(test, 'array_of_structs[1]')), variant_typeof(variant_extract(test, 'array_of_structs[2]')) from all_types offset 1 limit 1;
 ----
-OBJECT(a, b)
+OBJECT(a, b)	OBJECT(a, b)	VARIANT_NULL

--- a/test/sql/variant_typeof.test
+++ b/test/sql/variant_typeof.test
@@ -1,0 +1,70 @@
+# name: test/sql/variant_typeof.test
+# group: [sql]
+
+require variant
+
+require json
+
+query I
+select variant_typeof({'a': 42}::VARIANT);
+----
+OBJECT(a)
+
+query I
+select variant_typeof(({'a': 42}::VARIANT).variant_extract('a'));
+----
+INT32
+
+query I
+select variant_typeof(struct_pack(*COLUMNS(*))::VARIANT) test from test_all_types();
+----
+OBJECT(bool, tinyint, smallint, int, bigint, hugeint, uhugeint, utinyint, usmallint, uint, ubigint, varint, date, time, timestamp, timestamp_s, timestamp_ms, timestamp_ns, time_tz, timestamp_tz, float, double, dec_4_1, dec_9_4, dec_18_6, dec38_10, uuid, interval, varchar, blob, bit, small_enum, medium_enum, large_enum, int_array, double_array, date_array, timestamp_array, timestamptz_array, varchar_array, nested_int_array, struct, struct_of_arrays, array_of_structs, map, union, fixed_int_array, fixed_varchar_array, fixed_nested_int_array, fixed_nested_varchar_array, fixed_struct_array, struct_of_fixed_array, fixed_array_of_int_list, list_of_fixed_int_array)
+OBJECT(bool, tinyint, smallint, int, bigint, hugeint, uhugeint, utinyint, usmallint, uint, ubigint, varint, date, time, timestamp, timestamp_s, timestamp_ms, timestamp_ns, time_tz, timestamp_tz, float, double, dec_4_1, dec_9_4, dec_18_6, dec38_10, uuid, interval, varchar, blob, bit, small_enum, medium_enum, large_enum, int_array, double_array, date_array, timestamp_array, timestamptz_array, varchar_array, nested_int_array, struct, struct_of_arrays, array_of_structs, map, union, fixed_int_array, fixed_varchar_array, fixed_nested_int_array, fixed_nested_varchar_array, fixed_struct_array, struct_of_fixed_array, fixed_array_of_int_list, list_of_fixed_int_array)
+OBJECT(bool, tinyint, smallint, int, bigint, hugeint, uhugeint, utinyint, usmallint, uint, ubigint, varint, date, time, timestamp, timestamp_s, timestamp_ms, timestamp_ns, time_tz, timestamp_tz, float, double, dec_4_1, dec_9_4, dec_18_6, dec38_10, uuid, interval, varchar, blob, bit, small_enum, medium_enum, large_enum, int_array, double_array, date_array, timestamp_array, timestamptz_array, varchar_array, nested_int_array, struct, struct_of_arrays, array_of_structs, map, union, fixed_int_array, fixed_varchar_array, fixed_nested_int_array, fixed_nested_varchar_array, fixed_struct_array, struct_of_fixed_array, fixed_array_of_int_list, list_of_fixed_int_array)
+
+statement ok
+create table all_types as select struct_pack(*COLUMNS(*))::VARIANT test from test_all_types();
+
+query I
+select variant_typeof(variant_extract(test, 'bool')) from all_types;
+----
+BOOL_FALSE
+BOOL_TRUE
+VARIANT_NULL
+
+query I
+select variant_typeof(variant_extract(test, 'struct')) from all_types;
+----
+OBJECT(a, b)
+OBJECT(a, b)
+VARIANT_NULL
+
+statement error
+select variant_typeof(variant_extract(test, 'struct.a')) from all_types;
+----
+Invalid Input Error: 'OBJECT' was expected, found 'VARIANT_NULL', can't convert VARIANT
+
+query I
+select variant_typeof(variant_extract(test, 'struct.a')) from all_types limit 2;
+----
+VARIANT_NULL
+INT32
+
+query I
+select variant_typeof(variant_extract(test, 'dec_18_6')) from all_types
+----
+DECIMAL(18, 6)
+DECIMAL(18, 6)
+VARIANT_NULL
+
+query I
+select variant_typeof(variant_extract(test, 'array_of_structs')) from all_types
+----
+ARRAY(0)
+ARRAY(3)
+VARIANT_NULL
+
+query I
+select variant_typeof(variant_extract(test, 'array_of_structs[0]')), variant_typeof(variant_extract(test, 'array_of_structs[1]')), variant_typeof(variant_extract(test, 'array_of_structs[2]')) from all_types offset 1 limit 1;
+----
+OBJECT(a, b)


### PR DESCRIPTION
The `variant_typeof` function returns the underlying `VariantLogicalType` of the top-level value of the row.

For `OBJECT`, the keys are added, i.e: `OBJECT(a, b, c)`
For `ARRAY`, the length of the array is added, i.e: `ARRAY(10)`
For `DECIMAL`, the width+scale of the decimal value is added, i.e: `DECIMAL(16, 8)`